### PR TITLE
Travis test and upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+sudo: false
+
+language: python
+
+install:
+  - 'pip install awscli'
+
+script:
+  - |
+    for template in $(ls *.yml); do
+      aws cloudformation validate-template --template-body file://$template
+    done
+
+before_deploy:
+  - 'mkdir -p templates'
+  - 'cp *.yml templates'
+deploy:
+  # Deploy templates in `s3://thebucket/org/repo/branch-name`.
+  - provider: 's3'
+    access_key_id: '$AWS_ACCESS_KEY_ID'
+    secret_access_key: '$AWS_SECRET_ACCESS_KEY'
+    bucket: '$S3_BUCKET'
+    region: '$S3_REGION'
+    upload-dir: '$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH'
+    acl: 'public_read'
+    skip_cleanup: true
+    local_dir: 'templates'
+    on:
+      repo: 'chialab/aws-autoscaling-gitlab-runner'
+  # Deploy templates in `s3://thebucket/org/repo/commit-sha`.
+  - provider: 's3'
+    access_key_id: '$AWS_ACCESS_KEY_ID'
+    secret_access_key: '$AWS_SECRET_ACCESS_KEY'
+    bucket: '$S3_BUCKET'
+    region: '$S3_REGION'
+    upload-dir: '$TRAVIS_REPO_SLUG/$TRAVIS_COMMIT'
+    acl: 'public_read'
+    skip_cleanup: true
+    local_dir: 'templates'
+    on:
+      repo: 'chialab/aws-autoscaling-gitlab-runner'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ deploy:
     local_dir: 'templates'
     on:
       repo: 'Chialab/aws-autoscaling-gitlab-runner'
+      all_branches: true
   # Deploy templates in `s3://thebucket/org/repo/commit-sha`.
   - provider: 's3'
     access_key_id: '$AWS_ACCESS_KEY_ID'
@@ -36,3 +37,4 @@ deploy:
     local_dir: 'templates'
     on:
       repo: 'Chialab/aws-autoscaling-gitlab-runner'
+      all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - 'pip install awscli'
 
 script:
-  - 'for template in $(ls *.yml); do aws cloudformation validate-template --template-body file://$template done'
+  - 'for template in $(ls *.yml); do aws cloudformation validate-template --template-body file://$template; done'
 
 before_deploy:
   - 'mkdir -p templates'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,7 @@ install:
   - 'pip install awscli'
 
 script:
-  - |
-    for template in $(ls *.yml); do
-      aws cloudformation validate-template --template-body file://$template
-    done
+  - 'for template in $(ls *.yml); do aws cloudformation validate-template --template-body file://$template done'
 
 before_deploy:
   - 'mkdir -p templates'
@@ -19,8 +16,8 @@ deploy:
   - provider: 's3'
     access_key_id: '$AWS_ACCESS_KEY_ID'
     secret_access_key: '$AWS_SECRET_ACCESS_KEY'
+    region: '$AWS_DEFAULT_REGION'
     bucket: '$S3_BUCKET'
-    region: '$S3_REGION'
     upload-dir: '$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH'
     acl: 'public_read'
     skip_cleanup: true
@@ -31,8 +28,8 @@ deploy:
   - provider: 's3'
     access_key_id: '$AWS_ACCESS_KEY_ID'
     secret_access_key: '$AWS_SECRET_ACCESS_KEY'
+    region: '$AWS_DEFAULT_REGION'
     bucket: '$S3_BUCKET'
-    region: '$S3_REGION'
     upload-dir: '$TRAVIS_REPO_SLUG/$TRAVIS_COMMIT'
     acl: 'public_read'
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ deploy:
     skip_cleanup: true
     local_dir: 'templates'
     on:
-      repo: 'chialab/aws-autoscaling-gitlab-runner'
+      repo: 'Chialab/aws-autoscaling-gitlab-runner'
   # Deploy templates in `s3://thebucket/org/repo/commit-sha`.
   - provider: 's3'
     access_key_id: '$AWS_ACCESS_KEY_ID'
@@ -35,4 +35,4 @@ deploy:
     skip_cleanup: true
     local_dir: 'templates'
     on:
-      repo: 'chialab/aws-autoscaling-gitlab-runner'
+      repo: 'Chialab/aws-autoscaling-gitlab-runner'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Autoscaling GitLab Runner on AWS
-================================
+Autoscaling GitLab Runner on AWS [![Launch this stack on AWS](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=GitLabRunner&templateURL=https://s3-eu-west-1.amazonaws.com/chialab-cloudformation-templates/Chialab/aws-autoscaling-gitlab-runner/master/runner.yml)
+================================================================================
 
 This repository consists of an AWS CloudFormation template that may be used
 to deploy a GitLab runner with Docker executor and auto-scaling based on number


### PR DESCRIPTION
This MR introduces a build on Travis CI that:

- [x] attempts to validate the CloudFormation template using `aws cloudformation validate-template` command
- [x] uploads the template on a S3 bucket, with both keys:
  * `organization/repository/branch-or-tag-name/runner.yml`
  * `organization/repository/commit-sha/runner.yml`

It should now be possible to create a "launch stack" button to deploy this stack on AWS with one click, that has the latest available version of the template on branch `master`.

[![Launch this stack on AWS](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=GitLabRunner&templateURL=https://s3-eu-west-1.amazonaws.com/chialab-cloudformation-templates/Chialab/aws-autoscaling-gitlab-runner/master/runner.yml)

**Fun Fact**: this is a GitHub repository with a Travis CI build for deploying a CI runner for projects on GitLab with a GitLab CI build.