### PR TITLE
More restrictive IAM policy

### DIFF
--- a/runner.yml
+++ b/runner.yml
@@ -244,6 +244,9 @@ Resources:
       IamInstanceProfile: !Ref 'ManagerInstanceProfile'
       SecurityGroupIds:
         - !Ref 'ManagerSecurityGroup'
+      Tags:
+        - Key: 'Name'
+          Value: !Ref 'AWS::StackName'
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash -xe

--- a/runner.yml
+++ b/runner.yml
@@ -227,7 +227,7 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash -xe
-          yum update aws-cfn-bootstrap
+          yum update -y aws-cfn-bootstrap
 
           # Install the files and packages from the metadata
           /opt/aws/bin/cfn-init --stack '${AWS::StackName}' --region '${AWS::Region}' --resource Manager --configsets default

--- a/runner.yml
+++ b/runner.yml
@@ -346,9 +346,22 @@ Resources:
                     OffPeakPeriods = ["* * 0-9,18-23 * * mon-fri *", "* * * * * sat,sun *"]
                     OffPeakIdleCount = ${GitlabOffPeakIdleCount}
                     OffPeakIdleTime = ${GitlabOffPeakIdleTime}
-          commands:
-            10-restart:
-              command: gitlab-runner restart
+            '/etc/rsyslog.d/25-gitlab-runner.conf':
+              owner: 'root'
+              group: 'root'
+              mode: '000644'
+              content: |
+                :programname, isequal, "gitlab-runner" /var/log/gitlab-runner.log
+          services:
+            sysvinit:
+              gitlab-runner:
+                ensureRunning: 'true'
+                enabled: 'true'
+                files: ['/etc/gitlab-runner/config.toml']
+              rsyslog:
+                ensureRunning: 'true'
+                enabled: 'true'
+                files: ['/etc/rsyslog.d/25-gitlab-runner.conf']
     CreationPolicy:
       ResourceSignal:
         Timeout: 'PT15M'

--- a/runner.yml
+++ b/runner.yml
@@ -184,9 +184,21 @@ Resources:
                   - 'ec2:DeleteKeyPair'
                   - 'ec2:ImportKeyPair'
                   - 'ec2:Describe*'
+                Resource:
+                  - '*'
+              - Effect: 'Allow'
+                Action:
                   - 'ec2:CreateTags'
                 Resource:
                   - '*'
+                Condition:
+                  StringEquals:
+                    'ec2:Region': !Ref 'AWS::Region'
+                    'ec2:InstanceType': !Ref 'GitlabRunnerInstanceType'
+                  StringLike:
+                    'aws:RequestTag/Name': '*gitlab-docker-machine-*'
+                  ForAllValues:StringEquals:
+                    'aws:TagKeys': ['Name']
               - Effect: 'Allow'
                 Action:
                   - 'ec2:RunInstances'
@@ -199,17 +211,25 @@ Resources:
                     'ec2:Tenancy': 'default'
                   ArnEqualsIfExists:
                     'ec2:Vpc': !Sub 'arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/${VpcId}'
+                    'ec2:InstanceProfile': !GetAtt 'RunnersInstanceProfile.Arn'
               - Effect: 'Allow'
                 Action:
                   - 'ec2:TerminateInstances'
                   - 'ec2:StopInstances'
                   - 'ec2:StartInstances'
                   - 'ec2:RebootInstances'
+                Resource:
+                  - '*'
                 Condition:
                   StringLike:
                     'ec2:ResourceTag/Name': '*gitlab-docker-machine-*'
+                  ArnEquals:
+                    'ec2:InstanceProfile': !GetAtt 'RunnersInstanceProfile.Arn'
+              - Effect: 'Allow'
+                Action:
+                  - 'iam:PassRole'
                 Resource:
-                  - '*'
+                  - !GetAtt 'RunnersRole.Arn'
   ManagerInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
@@ -318,7 +338,7 @@ Resources:
                     MaxBuilds = ${GitlabMaxConcurrentBuilds}
                     MachineDriver = "amazonec2"
                     MachineName = "gitlab-docker-machine-%s"
-                    MachineOptions = ["amazonec2-instance-type=${GitlabRunnerInstanceType}", "amazonec2-region=${AWS::Region}", "amazonec2-vpc-id=${VpcId}", "amazonec2-security-group=${AWS::StackName}-RunnersSecurityGroup", "amazonec2-use-private-address=true"]
+                    MachineOptions = ["amazonec2-instance-type=${GitlabRunnerInstanceType}", "amazonec2-region=${AWS::Region}", "amazonec2-vpc-id=${VpcId}", "amazonec2-security-group=${AWS::StackName}-RunnersSecurityGroup", "amazonec2-use-private-address=true", "amazonec2-iam-instance-profile=${RunnersInstanceProfile}"]
                     OffPeakTimezone = "${GitlabOffPeakTimezone}"
                     OffPeakPeriods = ["* * 0-9,18-23 * * mon-fri *", "* * * * * sat,sun *"]
                     OffPeakIdleCount = ${GitlabOffPeakIdleCount}
@@ -340,6 +360,22 @@ Resources:
   ######################
   ### GitLab Runners ###
   ######################
+  RunnersRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service:
+                - 'ec2.amazonaws.com'
+            Action:
+              - 'sts:AssumeRole'
+  RunnersInstanceProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      Roles:
+        - !Ref 'RunnersRole'
   RunnersSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:


### PR DESCRIPTION
This Pull Request resolves #2.

Changes:
- "executor" instances (= EC2 instances created by Docker Machine to execute pending jobs) have now an IAM Instance Profile assigned with no permissions. This is quite hacky, but maybe not as awful as it might seem.
- "manager" instance is now named after the CloudFormation stack, and its permissions to start/stop/reboot/terminate other EC2 instances are now limited by the IAM Instance Profile attached to the target instance rather than its "Name" tag only.
- all `gitlab-runner` logs are now collected in `/var/log/gitlab-runner.log` through rsyslog.
- added flag `-y` to `yum install` — I wonder why it worked…?