### PR TITLE
Add missing quotes

### DIFF
--- a/runner.yml
+++ b/runner.yml
@@ -35,7 +35,7 @@ Parameters:
   SubnetId:
     Type: 'AWS::EC2::Subnet::Id'
     Description: |
-      ID of Subnet where resources will be created. 
+      ID of Subnet where resources will be created.
   ManagerImageId:
     Type: 'AWS::EC2::Image::Id'
     Description: |
@@ -44,7 +44,42 @@ Parameters:
     Type: 'String'
     Description: |
       Instance type for GitLab Runners' manager.
-    AllowedValues: ['c1.medium','c1.xlarge','c3.2xlarge','c3.4xlarge','c3.8xlarge','c3.large','c3.xlarge','c4.2xlarge','c4.4xlarge','c4.8xlarge','c4.large','c4.xlarge','c5.18xlarge','c5.2xlarge','c5.4xlarge','c5.9xlarge','c5d.18xlarge','c5d.2xlarge','c5d.4xlarge','c5d.9xlarge','c5d.large','c5d.xlarge','c5.large','c5.xlarge','cc2.8xlarge','cr1.8xlarge','d2.2xlarge','d2.4xlarge','d2.8xlarge','d2.xlarge','f1.16xlarge','f1.2xlarge','g2.2xlarge','g2.8xlarge','g3.16xlarge','g3.4xlarge','g3.8xlarge','h1.16xlarge','h1.2xlarge','h1.4xlarge','h1.8xlarge','hs1.8xlarge','i2.2xlarge','i2.4xlarge','i2.8xlarge','i2.xlarge','i3.16xlarge','i3.2xlarge','i3.4xlarge','i3.8xlarge','i3.large','i3.metal','i3.xlarge','m1.large','m1.medium','m1.small','m1.xlarge','m2.2xlarge','m2.4xlarge','m2.xlarge','m3.2xlarge','m3.large','m3.medium','m3.xlarge','m4.10xlarge','m4.16xlarge','m4.2xlarge','m4.4xlarge','m4.large','m4.xlarge','m5.12xlarge','m5.24xlarge','m5.2xlarge','m5.4xlarge','m5d.12xlarge','m5d.24xlarge','m5d.2xlarge','m5d.4xlarge','m5d.large','m5d.xlarge','m5.large','m5.xlarge','p2.16xlarge','p2.8xlarge','p2.xlarge','p3.16xlarge','p3.2xlarge','p3.8xlarge','r3.2xlarge','r3.4xlarge','r3.8xlarge','r3.large','r3.xlarge','r4.16xlarge','r4.2xlarge','r4.4xlarge','r4.8xlarge','r4.large','r4.xlarge','r5.12xlarge','r5.24xlarge','r5.2xlarge','r5.4xlarge','r5d.12xlarge','r5d.24xlarge','r5d.2xlarge','r5d.4xlarge','r5d.large','r5d.xlarge','r5.large','r5.xlarge','t1.micro','t2.2xlarge','t2.large','t2.medium','t2.micro','t2.nano','t2.small','t2.xlarge','t3.2xlarge','t3.large','t3.medium','t3.micro','t3.nano','t3.small','t3.xlarge','x1.16xlarge','x1.32xlarge','x1e.16xlarge','x1e.2xlarge','x1e.32xlarge','x1e.4xlarge','x1e.8xlarge','x1e.xlarge','z1d.12xlarge','z1d.2xlarge','z1d.3xlarge','z1d.6xlarge','z1d.large','z1d.xlarge']
+    AllowedValues: [
+      'c1.medium', 'c1.xlarge',
+      'c3.large', 'c3.xlarge', 'c3.2xlarge', 'c3.4xlarge', 'c3.8xlarge',
+      'c4.large', 'c4.xlarge', 'c4.2xlarge', 'c4.4xlarge', 'c4.8xlarge',
+      'c5.large', 'c5.xlarge', 'c5.2xlarge', 'c5.4xlarge', 'c5.9xlarge', 'c5.18xlarge',
+      'c5d.large', 'c5d.xlarge', 'c5d.2xlarge', 'c5d.4xlarge', 'c5d.9xlarge', 'c5d.18xlarge',
+      'cc2.8xlarge',
+      'cr1.8xlarge',
+      'd2.xlarge', 'd2.2xlarge', 'd2.4xlarge', 'd2.8xlarge',
+      'f1.2xlarge', 'f1.16xlarge',
+      'g2.2xlarge', 'g2.8xlarge',
+      'g3.4xlarge', 'g3.8xlarge', 'g3.16xlarge',
+      'h1.2xlarge', 'h1.4xlarge', 'h1.8xlarge', 'h1.16xlarge',
+      'hs1.8xlarge',
+      'i2.xlarge', 'i2.2xlarge', 'i2.4xlarge', 'i2.8xlarge',
+      'i3.large', 'i3.xlarge', 'i3.2xlarge', 'i3.4xlarge', 'i3.8xlarge', 'i3.16xlarge', 'i3.metal',
+      'm1.small', 'm1.medium', 'm1.large', 'm1.xlarge',
+      'm2.xlarge', 'm2.2xlarge', 'm2.4xlarge',
+      'm3.medium', 'm3.large', 'm3.xlarge', 'm3.2xlarge',
+      'm4.large', 'm4.xlarge', 'm4.2xlarge', 'm4.4xlarge', 'm4.10xlarge', 'm4.16xlarge',
+      'm5.large', 'm5.xlarge', 'm5.2xlarge', 'm5.4xlarge', 'm5.12xlarge', 'm5.24xlarge',
+      'm5d.large', 'm5d.xlarge', 'm5d.2xlarge', 'm5d.4xlarge', 'm5d.12xlarge', 'm5d.24xlarge',
+      'p2.xlarge', 'p2.8xlarge', 'p2.16xlarge',
+      'p3.2xlarge', 'p3.8xlarge', 'p3.16xlarge',
+      'r3.large', 'r3.xlarge', 'r3.2xlarge', 'r3.4xlarge', 'r3.8xlarge',
+      'r4.large', 'r4.xlarge', 'r4.2xlarge', 'r4.4xlarge', 'r4.8xlarge', 'r4.16xlarge',
+      'r5.2xlarge', 'r5.4xlarge', 'r5.12xlarge', 'r5.24xlarge',
+      'r5d.large', 'r5d.xlarge', 'r5d.2xlarge', 'r5d.4xlarge', 'r5d.12xlarge', 'r5d.24xlarge',
+      'r5.large', 'r5.xlarge',
+      't1.micro',
+      't2.nano', 't2.micro', 't2.small', 't2.medium', 't2.large', 't2.xlarge', 't2.2xlarge',
+      't3.nano', 't3.micro', 't3.small', 't3.medium', 't3.large', 't3.xlarge', 't3.2xlarge',
+      'x1.16xlarge', 'x1.32xlarge',
+      'x1e.xlarge', 'x1e.2xlarge', 'x1e.4xlarge', 'x1e.8xlarge', 'x1e.16xlarge', 'x1e.32xlarge',
+      'z1d.large', 'z1d.xlarge', 'z1d.2xlarge', 'z1d.3xlarge', 'z1d.6xlarge', 'z1d.12xlarge',
+    ]
     Default: 't3.nano'
   ManagerKeyPair:
     Type: 'AWS::EC2::KeyPair::KeyName'
@@ -64,17 +99,52 @@ Parameters:
     Type: 'String'
     Description: |
       Instance type for GitLab Runners.
-    AllowedValues: ['c1.medium','c1.xlarge','c3.2xlarge','c3.4xlarge','c3.8xlarge','c3.large','c3.xlarge','c4.2xlarge','c4.4xlarge','c4.8xlarge','c4.large','c4.xlarge','c5.18xlarge','c5.2xlarge','c5.4xlarge','c5.9xlarge','c5d.18xlarge','c5d.2xlarge','c5d.4xlarge','c5d.9xlarge','c5d.large','c5d.xlarge','c5.large','c5.xlarge','cc2.8xlarge','cr1.8xlarge','d2.2xlarge','d2.4xlarge','d2.8xlarge','d2.xlarge','f1.16xlarge','f1.2xlarge','g2.2xlarge','g2.8xlarge','g3.16xlarge','g3.4xlarge','g3.8xlarge','h1.16xlarge','h1.2xlarge','h1.4xlarge','h1.8xlarge','hs1.8xlarge','i2.2xlarge','i2.4xlarge','i2.8xlarge','i2.xlarge','i3.16xlarge','i3.2xlarge','i3.4xlarge','i3.8xlarge','i3.large','i3.metal','i3.xlarge','m1.large','m1.medium','m1.small','m1.xlarge','m2.2xlarge','m2.4xlarge','m2.xlarge','m3.2xlarge','m3.large','m3.medium','m3.xlarge','m4.10xlarge','m4.16xlarge','m4.2xlarge','m4.4xlarge','m4.large','m4.xlarge','m5.12xlarge','m5.24xlarge','m5.2xlarge','m5.4xlarge','m5d.12xlarge','m5d.24xlarge','m5d.2xlarge','m5d.4xlarge','m5d.large','m5d.xlarge','m5.large','m5.xlarge','p2.16xlarge','p2.8xlarge','p2.xlarge','p3.16xlarge','p3.2xlarge','p3.8xlarge','r3.2xlarge','r3.4xlarge','r3.8xlarge','r3.large','r3.xlarge','r4.16xlarge','r4.2xlarge','r4.4xlarge','r4.8xlarge','r4.large','r4.xlarge','r5.12xlarge','r5.24xlarge','r5.2xlarge','r5.4xlarge','r5d.12xlarge','r5d.24xlarge','r5d.2xlarge','r5d.4xlarge','r5d.large','r5d.xlarge','r5.large','r5.xlarge','t1.micro','t2.2xlarge','t2.large','t2.medium','t2.micro','t2.nano','t2.small','t2.xlarge','t3.2xlarge','t3.large','t3.medium','t3.micro','t3.nano','t3.small','t3.xlarge','x1.16xlarge','x1.32xlarge','x1e.16xlarge','x1e.2xlarge','x1e.32xlarge','x1e.4xlarge','x1e.8xlarge','x1e.xlarge','z1d.12xlarge','z1d.2xlarge','z1d.3xlarge','z1d.6xlarge','z1d.large','z1d.xlarge']
+    AllowedValues: [
+      'c1.medium', 'c1.xlarge',
+      'c3.large', 'c3.xlarge', 'c3.2xlarge', 'c3.4xlarge', 'c3.8xlarge',
+      'c4.large', 'c4.xlarge', 'c4.2xlarge', 'c4.4xlarge', 'c4.8xlarge',
+      'c5.large', 'c5.xlarge', 'c5.2xlarge', 'c5.4xlarge', 'c5.9xlarge', 'c5.18xlarge',
+      'c5d.large', 'c5d.xlarge', 'c5d.2xlarge', 'c5d.4xlarge', 'c5d.9xlarge', 'c5d.18xlarge',
+      'cc2.8xlarge',
+      'cr1.8xlarge',
+      'd2.xlarge', 'd2.2xlarge', 'd2.4xlarge', 'd2.8xlarge',
+      'f1.2xlarge', 'f1.16xlarge',
+      'g2.2xlarge', 'g2.8xlarge',
+      'g3.4xlarge', 'g3.8xlarge', 'g3.16xlarge',
+      'h1.2xlarge', 'h1.4xlarge', 'h1.8xlarge', 'h1.16xlarge',
+      'hs1.8xlarge',
+      'i2.xlarge', 'i2.2xlarge', 'i2.4xlarge', 'i2.8xlarge',
+      'i3.large', 'i3.xlarge', 'i3.2xlarge', 'i3.4xlarge', 'i3.8xlarge', 'i3.16xlarge', 'i3.metal',
+      'm1.small', 'm1.medium', 'm1.large', 'm1.xlarge',
+      'm2.xlarge', 'm2.2xlarge', 'm2.4xlarge',
+      'm3.medium', 'm3.large', 'm3.xlarge', 'm3.2xlarge',
+      'm4.large', 'm4.xlarge', 'm4.2xlarge', 'm4.4xlarge', 'm4.10xlarge', 'm4.16xlarge',
+      'm5.large', 'm5.xlarge', 'm5.2xlarge', 'm5.4xlarge', 'm5.12xlarge', 'm5.24xlarge',
+      'm5d.large', 'm5d.xlarge', 'm5d.2xlarge', 'm5d.4xlarge', 'm5d.12xlarge', 'm5d.24xlarge',
+      'p2.xlarge', 'p2.8xlarge', 'p2.16xlarge',
+      'p3.2xlarge', 'p3.8xlarge', 'p3.16xlarge',
+      'r3.large', 'r3.xlarge', 'r3.2xlarge', 'r3.4xlarge', 'r3.8xlarge',
+      'r4.large', 'r4.xlarge', 'r4.2xlarge', 'r4.4xlarge', 'r4.8xlarge', 'r4.16xlarge',
+      'r5.2xlarge', 'r5.4xlarge', 'r5.12xlarge', 'r5.24xlarge',
+      'r5d.large', 'r5d.xlarge', 'r5d.2xlarge', 'r5d.4xlarge', 'r5d.12xlarge', 'r5d.24xlarge',
+      'r5.large', 'r5.xlarge',
+      't1.micro',
+      't2.nano', 't2.micro', 't2.small', 't2.medium', 't2.large', 't2.xlarge', 't2.2xlarge',
+      't3.nano', 't3.micro', 't3.small', 't3.medium', 't3.large', 't3.xlarge', 't3.2xlarge',
+      'x1.16xlarge', 'x1.32xlarge',
+      'x1e.xlarge', 'x1e.2xlarge', 'x1e.4xlarge', 'x1e.8xlarge', 'x1e.16xlarge', 'x1e.32xlarge',
+      'z1d.large', 'z1d.xlarge', 'z1d.2xlarge', 'z1d.3xlarge', 'z1d.6xlarge', 'z1d.12xlarge',
+    ]
     Default: 't3.micro'
   GitlabDockerImage:
     Type: 'String'
     Description: |
-      Name of the docker image to be used.
+      Name of the Docker image to be used.
     Default: 'alpine:latest'
   GitlabMaxBuilds:
     Type: 'Number'
     Description: |
-      Maximum number of builds before the runner is terminated
+      Maximum number of builds before the runner is terminated.
     MinValue: 1
     Default: 10
   GitlabMaxConcurrentBuilds:
@@ -99,7 +169,16 @@ Parameters:
     Type: 'String'
     Description: |
       Timezone in which non-working hours are evaluated.
-    AllowedValues: ['Africa/Algiers', 'Africa/Cairo', 'Africa/Casablaca', 'Africa/Harare', 'Africa/Johaesburg', 'Africa/Morovia', 'Africa/airobi', 'America/Argetia/Bueos_Aires', 'America/Bogota', 'America/Caracas', 'America/Chicago', 'America/Chihuahua', 'America/Dever', 'America/Godthab', 'America/Guatemala', 'America/Guyaa', 'America/Halifax', 'America/Idiaa/Idiaapolis', 'America/Jueau', 'America/La_Paz', 'America/Lima', 'America/Los_Ageles', 'America/Mazatla', 'America/Mexico_City', 'America/Moterrey', 'America/Motevideo', 'America/ew_York', 'America/Phoeix', 'America/Regia', 'America/Satiago', 'America/Sao_Paulo', 'America/St_Johs', 'America/Tijuaa', 'Asia/Almaty', 'Asia/Baghdad', 'Asia/Baku', 'Asia/Bagkok', 'Asia/Chogqig', 'Asia/Colombo', 'Asia/Dhaka', 'Asia/Hog_Kog', 'Asia/Irkutsk', 'Asia/Jakarta', 'Asia/Jerusalem', 'Asia/Kabul', 'Asia/Kamchatka', 'Asia/Karachi', 'Asia/Kathmadu', 'Asia/Kolkata', 'Asia/Krasoyarsk', 'Asia/Kuala_Lumpur', 'Asia/Kuwait', 'Asia/Magada', 'Asia/Muscat', 'Asia/ovosibirsk', 'Asia/Ragoo', 'Asia/Riyadh', 'Asia/Seoul', 'Asia/Shaghai', 'Asia/Sigapore', 'Asia/Taipei', 'Asia/Tashket', 'Asia/Tbilisi', 'Asia/Tehra', 'Asia/Tokyo', 'Asia/Ulaabaatar', 'Asia/Urumqi', 'Asia/Vladivostok', 'Asia/Yakutsk', 'Asia/Yekateriburg', 'Asia/Yereva', 'Atlatic/Azores', 'Atlatic/Cape_Verde', 'Atlatic/South_Georgia', 'Australia/Adelaide', 'Australia/Brisbae', 'Australia/Darwi', 'Australia/Hobart', 'Australia/Melboure', 'Australia/Perth', 'Australia/Sydey', 'Etc/UTC', 'Europe/Amsterdam', 'Europe/Athes', 'Europe/Belgrade', 'Europe/Berli', 'Europe/Bratislava', 'Europe/Brussels', 'Europe/Bucharest', 'Europe/Budapest', 'Europe/Copehage', 'Europe/Dubli', 'Europe/Helsiki', 'Europe/Istabul', 'Europe/Kiev', 'Europe/Lisbo', 'Europe/Ljubljaa', 'Europe/Lodo', 'Europe/Madrid', 'Europe/Misk', 'Europe/Moscow', 'Europe/Paris', 'Europe/Prague', 'Europe/Riga', 'Europe/Rome', 'Europe/Sarajevo', 'Europe/Skopje', 'Europe/Sofia', 'Europe/Stockholm', 'Europe/Talli', 'Europe/Viea', 'Europe/Vilius', 'Europe/Warsaw', 'Europe/Zagreb', 'Pacific/Apia', 'Pacific/Aucklad', 'Pacific/Chatham', 'Pacific/Fakaofo', 'Pacific/Fiji', 'Pacific/Guadalcaal', 'Pacific/Guam', 'Pacific/Hoolulu', 'Pacific/Majuro', 'Pacific/Midway', 'Pacific/oumea', 'Pacific/Pago_Pago', 'Pacific/Port_Moresby', 'Pacific/Togatapu']
+    AllowedValues: [
+      'Africa/Algiers', 'Africa/Cairo', 'Africa/Casablaca', 'Africa/Harare', 'Africa/Johaesburg', 'Africa/Morovia', 'Africa/airobi',
+      'America/Argetia/Bueos_Aires', 'America/Bogota', 'America/Caracas', 'America/Chicago', 'America/Chihuahua', 'America/Dever', 'America/Godthab', 'America/Guatemala', 'America/Guyaa', 'America/Halifax', 'America/Idiaa/Idiaapolis', 'America/Jueau', 'America/La_Paz', 'America/Lima', 'America/Los_Ageles', 'America/Mazatla', 'America/Mexico_City', 'America/Moterrey', 'America/Motevideo', 'America/ew_York', 'America/Phoeix', 'America/Regia', 'America/Satiago', 'America/Sao_Paulo', 'America/St_Johs', 'America/Tijuaa',
+      'Asia/Almaty', 'Asia/Baghdad', 'Asia/Baku', 'Asia/Bagkok', 'Asia/Chogqig', 'Asia/Colombo', 'Asia/Dhaka', 'Asia/Hog_Kog', 'Asia/Irkutsk', 'Asia/Jakarta', 'Asia/Jerusalem', 'Asia/Kabul', 'Asia/Kamchatka', 'Asia/Karachi', 'Asia/Kathmadu', 'Asia/Kolkata', 'Asia/Krasoyarsk', 'Asia/Kuala_Lumpur', 'Asia/Kuwait', 'Asia/Magada', 'Asia/Muscat', 'Asia/ovosibirsk', 'Asia/Ragoo', 'Asia/Riyadh', 'Asia/Seoul', 'Asia/Shaghai', 'Asia/Sigapore', 'Asia/Taipei', 'Asia/Tashket', 'Asia/Tbilisi', 'Asia/Tehra', 'Asia/Tokyo', 'Asia/Ulaabaatar', 'Asia/Urumqi', 'Asia/Vladivostok', 'Asia/Yakutsk', 'Asia/Yekateriburg', 'Asia/Yereva',
+      'Atlatic/Azores', 'Atlatic/Cape_Verde', 'Atlatic/South_Georgia',
+      'Australia/Adelaide', 'Australia/Brisbae', 'Australia/Darwi', 'Australia/Hobart', 'Australia/Melboure', 'Australia/Perth', 'Australia/Sydey',
+      'Etc/UTC',
+      'Europe/Amsterdam', 'Europe/Athes', 'Europe/Belgrade', 'Europe/Berli', 'Europe/Bratislava', 'Europe/Brussels', 'Europe/Bucharest', 'Europe/Budapest', 'Europe/Copehage', 'Europe/Dubli', 'Europe/Helsiki', 'Europe/Istabul', 'Europe/Kiev', 'Europe/Lisbo', 'Europe/Ljubljaa', 'Europe/Lodo', 'Europe/Madrid', 'Europe/Misk', 'Europe/Moscow', 'Europe/Paris', 'Europe/Prague', 'Europe/Riga', 'Europe/Rome', 'Europe/Sarajevo', 'Europe/Skopje', 'Europe/Sofia', 'Europe/Stockholm', 'Europe/Talli', 'Europe/Viea', 'Europe/Vilius', 'Europe/Warsaw', 'Europe/Zagreb',
+      'Pacific/Apia', 'Pacific/Aucklad', 'Pacific/Chatham', 'Pacific/Fakaofo', 'Pacific/Fiji', 'Pacific/Guadalcaal', 'Pacific/Guam', 'Pacific/Hoolulu', 'Pacific/Majuro', 'Pacific/Midway', 'Pacific/oumea', 'Pacific/Pago_Pago', 'Pacific/Port_Moresby', 'Pacific/Togatapu',
+    ]
     Default: 'Etc/UTC'
   GitlabOffPeakIdleCount:
     Type: 'Number'
@@ -113,17 +192,18 @@ Parameters:
       Number of seconds of inactivity before an idle host is shut down during non-working hours.
     MinValue: 1
     Default: 1200
-  GitLabRunnerSpotInstancePrice:
-    Type: 'String'
-    Description: |
-      Spot instance bid price.
-    Default: '0.08'
   GitLabRunnerSpotInstance:
     Type: 'String'
     Description: |
-      Will runners be spot instances ?
+      Will runners be spot instances?
     AllowedValues: ['Yes', 'No']
     Default: 'No'
+  GitLabRunnerSpotInstancePrice:
+    Type: 'Number'
+    MinValue: 0
+    Description: |
+      Spot instance bid price.
+    Default: 0.08
 
 Conditions:
   GivenBucketName: !Not [!Equals ['', !Ref 'CacheBucketName']]

--- a/runner.yml
+++ b/runner.yml
@@ -53,9 +53,10 @@ Parameters:
       'cc2.8xlarge',
       'cr1.8xlarge',
       'd2.xlarge', 'd2.2xlarge', 'd2.4xlarge', 'd2.8xlarge',
-      'f1.2xlarge', 'f1.16xlarge',
+      'f1.2xlarge', 'f1.4xlarge', 'f1.16xlarge',
       'g2.2xlarge', 'g2.8xlarge',
       'g3.4xlarge', 'g3.8xlarge', 'g3.16xlarge',
+      'g3s.xlarge',
       'h1.2xlarge', 'h1.4xlarge', 'h1.8xlarge', 'h1.16xlarge',
       'hs1.8xlarge',
       'i2.xlarge', 'i2.2xlarge', 'i2.4xlarge', 'i2.8xlarge',
@@ -70,9 +71,8 @@ Parameters:
       'p3.2xlarge', 'p3.8xlarge', 'p3.16xlarge',
       'r3.large', 'r3.xlarge', 'r3.2xlarge', 'r3.4xlarge', 'r3.8xlarge',
       'r4.large', 'r4.xlarge', 'r4.2xlarge', 'r4.4xlarge', 'r4.8xlarge', 'r4.16xlarge',
-      'r5.2xlarge', 'r5.4xlarge', 'r5.12xlarge', 'r5.24xlarge',
+      'r5.large', 'r5.xlarge', 'r5.2xlarge', 'r5.4xlarge', 'r5.12xlarge', 'r5.24xlarge',
       'r5d.large', 'r5d.xlarge', 'r5d.2xlarge', 'r5d.4xlarge', 'r5d.12xlarge', 'r5d.24xlarge',
-      'r5.large', 'r5.xlarge',
       't1.micro',
       't2.nano', 't2.micro', 't2.small', 't2.medium', 't2.large', 't2.xlarge', 't2.2xlarge',
       't3.nano', 't3.micro', 't3.small', 't3.medium', 't3.large', 't3.xlarge', 't3.2xlarge',
@@ -108,9 +108,10 @@ Parameters:
       'cc2.8xlarge',
       'cr1.8xlarge',
       'd2.xlarge', 'd2.2xlarge', 'd2.4xlarge', 'd2.8xlarge',
-      'f1.2xlarge', 'f1.16xlarge',
+      'f1.2xlarge', 'f1.4xlarge', 'f1.16xlarge',
       'g2.2xlarge', 'g2.8xlarge',
       'g3.4xlarge', 'g3.8xlarge', 'g3.16xlarge',
+      'g3s.xlarge',
       'h1.2xlarge', 'h1.4xlarge', 'h1.8xlarge', 'h1.16xlarge',
       'hs1.8xlarge',
       'i2.xlarge', 'i2.2xlarge', 'i2.4xlarge', 'i2.8xlarge',
@@ -125,9 +126,8 @@ Parameters:
       'p3.2xlarge', 'p3.8xlarge', 'p3.16xlarge',
       'r3.large', 'r3.xlarge', 'r3.2xlarge', 'r3.4xlarge', 'r3.8xlarge',
       'r4.large', 'r4.xlarge', 'r4.2xlarge', 'r4.4xlarge', 'r4.8xlarge', 'r4.16xlarge',
-      'r5.2xlarge', 'r5.4xlarge', 'r5.12xlarge', 'r5.24xlarge',
+      'r5.large', 'r5.xlarge', 'r5.2xlarge', 'r5.4xlarge', 'r5.12xlarge', 'r5.24xlarge',
       'r5d.large', 'r5d.xlarge', 'r5d.2xlarge', 'r5d.4xlarge', 'r5d.12xlarge', 'r5d.24xlarge',
-      'r5.large', 'r5.xlarge',
       't1.micro',
       't2.nano', 't2.micro', 't2.small', 't2.medium', 't2.large', 't2.xlarge', 't2.2xlarge',
       't3.nano', 't3.micro', 't3.small', 't3.medium', 't3.large', 't3.xlarge', 't3.2xlarge',
@@ -444,10 +444,11 @@ Resources:
                         shm_size = 0
                       [runners.cache]
                         Type = "s3"
+                        Shared = true
+                      [runners.cache.s3]
                         ServerAddress = "s3.${AWS::URLSuffix}"
                         BucketName = "${CacheBucket}"
                         BucketLocation = "${AWS::Region}"
-                        Shared = true
                       [runners.machine]
                         IdleCount = ${GitlabIdleCount}
                         IdleTime = ${GitlabIdleTime}

--- a/runner.yml
+++ b/runner.yml
@@ -344,7 +344,7 @@ Resources:
               owner: 'gitlab-runner'
               group: 'gitlab-runner'
               mode: '000600'
-              content: 
+              content:
                 Fn::Sub:
                   - |
                     concurrent = ${GitlabMaxConcurrentBuilds}
@@ -357,7 +357,7 @@ Resources:
                       executor = "docker+machine"
                       [runners.docker]
                         tls_verify = false
-                        image = ${GitlabDockerImage}
+                        image = "${GitlabDockerImage}"
                         privileged = true
                         disable_cache = true
                         volumes = ["/var/run/docker.sock:/var/run/docker.sock", "/cache"]
@@ -379,9 +379,7 @@ Resources:
                         OffPeakPeriods = ["* * 0-8,18-23 * * mon-fri *", "* * * * * sat,sun *"]
                         OffPeakIdleCount = ${GitlabOffPeakIdleCount}
                         OffPeakIdleTime = ${GitlabOffPeakIdleTime}
-                  - {
-                      LocalSpotVar: !If [UseSpotInstances, !Sub ', "amazonec2-request-spot-instance=true", "amazonec2-spot-price=${GitLabRunnerSpotInstancePrice}"', '']
-                    }
+                  - LocalSpotVar: !If ['UseSpotInstances', !Sub ', "amazonec2-request-spot-instance=true", "amazonec2-spot-price=${GitLabRunnerSpotInstancePrice}"', '']
             '/etc/rsyslog.d/25-gitlab-runner.conf':
               owner: 'root'
               group: 'root'


### PR DESCRIPTION
This MR fixes a critical issue introduced yesterday that caused GitLab runner to fail at startup due to missing quotes around default Docker image name.